### PR TITLE
Implement dbcs_alloc for PASE in PDO_IBM

### DIFF
--- a/ibm_statement.c
+++ b/ibm_statement.c
@@ -1084,6 +1084,10 @@ static int stmt_bind_column(pdo_stmt_t *stmt, int colno)
 		case SQL_NUMERIC:
 		default:
 			in_length = col_res->data_size + in_length;
+			/* this includes null terminator, so a bit sloppy */
+			if (PDO_IBM_G(i5_dbcs_alloc)) {
+				in_length *= 6;
+			}
 			col_res->data.str_val = (char *) emalloc(in_length+1);
 			check_stmt_allocation(col_res->data.str_val,
 					"stmt_bind_column",

--- a/pdo_ibm.c
+++ b/pdo_ibm.c
@@ -85,6 +85,8 @@ ZEND_GET_MODULE(pdo_ibm)
 PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("pdo_ibm.i5_override_ccsid", "0", PHP_INI_SYSTEM, OnUpdateLong,
 		i5_override_ccsid, zend_pdo_ibm_globals, pdo_ibm_globals)
+	STD_PHP_INI_ENTRY("pdo_ibm.i5_dbcs_alloc", "0", PHP_INI_SYSTEM, OnUpdateLong,
+		i5_dbcs_alloc, zend_pdo_ibm_globals, pdo_ibm_globals)
 PHP_INI_END()
 #endif /* PASE */
 

--- a/php_pdo_ibm.h
+++ b/php_pdo_ibm.h
@@ -51,6 +51,7 @@ ZEND_BEGIN_MODULE_GLOBALS(pdo_ibm)
 #ifdef PASE /* i5/OS ease of use turn off/on */
 	long		i5_ignore_userid; 		/* blank userid, possible no qsqsrvr  */
 	long		i5_override_ccsid; 		/* prior any CLI routine override ascii ccsid */
+	long		i5_dbcs_alloc;			/* if to overallocate buffers for unpredictable conversions */
 #endif /* PASE */
 ZEND_END_MODULE_GLOBALS(pdo_ibm)
 


### PR DESCRIPTION
ibm_db2 has it, and it's an unfortunate workaround that's sometimes needed to do how unreliable it can be to detected truncation. Ideally this option should be made obsolete, but until it can be, this can be enabled for situations where EBCDIC characters expand into longer UTF-8 ones.

Running the tests, none seem affected, same amount of pass/fail.