### PR TITLE
Cleanup autotools scripts

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -71,11 +71,6 @@ if test "$PHP_PDO_IBM" != "no"; then
   dnl Don't forget to add additional source files here
   php_pdo_ibm_sources_core="pdo_ibm.c ibm_driver.c ibm_statement.c"
 
-  case "$host_alias" in
-    *aix*)
-      CPPFLAGS="$CPPFLAGS -D__H_LOCALEDEF";;
-  esac
-
   dnl Convert the includes to __PASE__ (for IBM-shipped GCC) or use AC_DEFINE
   if test "$PDO_IBM_PASE" = "yes" ; then
     PHP_NEW_EXTENSION(pdo_ibm, $php_pdo_ibm_sources_core, $ext_shared,,-I$pdo_cv_inc_path -DPASE)

--- a/config.m4
+++ b/config.m4
@@ -17,20 +17,25 @@ if test "$PHP_PDO_IBM" != "no"; then
     dnl XXX: Macros for this? Can these be merged?
 
     dnl LUW ships its client libraries in lib64/32 (at least on amd64 linux)
-    PHP_CHECK_LIBRARY(db2, SQLDriverConnect, [
-      PHP_ADD_LIBPATH($i/lib64, PDO_IBM_SHARED_LIBADD)
-      PHP_ADD_LIBRARY(db2, 1, PDO_IBM_SHARED_LIBADD)
-      PHP_ADD_INCLUDE($i/include)
-      break
-    ], [
-    ], "-L$i/lib64" )
-    PHP_CHECK_LIBRARY(db2, SQLDriverConnect, [
-      PHP_ADD_LIBPATH($i/lib32, PDO_IBM_SHARED_LIBADD)
-      PHP_ADD_LIBRARY(db2, 1, PDO_IBM_SHARED_LIBADD)
-      PHP_ADD_INCLUDE($i/include)
-      break
-    ], [
-    ], "-L$i/lib32" )
+    AC_CHECK_SIZEOF([long])
+    AC_MSG_CHECKING([if we're on a 64-bit platform])
+    AS_IF([test "$ac_cv_sizeof_long" -eq 4],[
+      AC_MSG_RESULT([no])
+      PHP_CHECK_LIBRARY(db2, SQLDriverConnect, [
+        PHP_ADD_LIBPATH($i/lib32, PDO_IBM_SHARED_LIBADD)
+        PHP_ADD_LIBRARY(db2, 1, PDO_IBM_SHARED_LIBADD)
+        PHP_ADD_INCLUDE($i/include)
+        break
+      ], [], "-L$i/lib32" )
+    ],[
+      AC_MSG_RESULT([yes])
+      PHP_CHECK_LIBRARY(db2, SQLDriverConnect, [
+        PHP_ADD_LIBPATH($i/lib64, PDO_IBM_SHARED_LIBADD)
+        PHP_ADD_LIBRARY(db2, 1, PDO_IBM_SHARED_LIBADD)
+        PHP_ADD_INCLUDE($i/include)
+        break
+      ], [], "-L$i/lib64" )
+    ])
     dnl The standalone clidriver package uses lib/
     PHP_CHECK_LIBRARY(db2, SQLDriverConnect, [
       PHP_ADD_LIBPATH($i/lib, PDO_IBM_SHARED_LIBADD)

--- a/config.m4
+++ b/config.m4
@@ -83,10 +83,7 @@ if test "$PHP_PDO_IBM" != "no"; then
     PHP_NEW_EXTENSION(pdo_ibm, $php_pdo_ibm_sources_core, $ext_shared,,-I$pdo_cv_inc_path)
   fi
 
-  ifdef([PHP_ADD_EXTENSION_DEP],
-  [
-    PHP_ADD_EXTENSION_DEP(pdo_ibm, pdo)
-  ])
+  PHP_ADD_EXTENSION_DEP(pdo_ibm, pdo)
 
   PHP_SUBST(PDO_IBM_SHARED_LIBADD)
 


### PR DESCRIPTION
* Assumes PHP's autotools functions are from at least 2005.
* Simplify the search for libraries and includes.
* For PASE, simplify search, and support SG's libdb400 wrapper (used because of AIX loader limitatioons).

Fixes GH-14