### PR TITLE
Update `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Interface for PHP to DB2 for z/OS, DB2 for LUW, DB2 for i.
 
 ## Pre-requisites
 
-The minimum PHP version supported by driver is PHP 7.3 and the latest version supported is PHP 8.1.
+The minimum PHP version supported by driver is PHP 7.3 and the latest version supported is PHP 8.2.
 
 ## IBM i users
 
@@ -36,67 +36,77 @@ If not installed Download from the below link.
 PHP should be installed in your system.
 
 ## How to install php pdo_ibm extension in Linux/Mac
-```
-if IBM_DB_HOME and LD_LIBRARY_PATH environment variable not set then set them with installed CLIDRIVER.
-(say CLIDRIVER installed at "/home/user/clidriver")
 
+If `IBM_DB_HOME` and `LD_LIBRARY_PATH` environment variables are not set, then set them with installed CLIDRIVER.
+(say CLIDRIVER installed at `/home/user/clidriver`)
+
+```shell
 export IBM_DB_HOME=/home/user/clidriver 
-export LD_LIBRARY_PATH=/home/user/clidriver/lib
-
-1) pecl install pdo_ibm
-        
-2) Open the php.ini file in an editor of your choice. Edit the extension entry in the
-   php.ini file in the <local_php_directory>/php/lib directory to reference the PHP driver:
-       extension=pdo_ibm.so
-       
-3) Ensure that the PHP driver can access the libdb2.so CLI driver file by
-   setting the LD_LIBRARY_PATH variable for Linux and UNIX operating systems
-   other than the AIX® operating system. For AIX operating system, you must set LIBPATH variable. 
-
-4) Optional: If the PHP application that is connecting to an IBM database server is running ini
-   the HTTP server environment, add the LD_LIBRARY_PATH variable in the httpd.conf file.
-
+export LD_LIBRARY_PATH="${IBM_DB_HOME}/lib"
 ```
+
+1. Install this extension:
+
+   ```shell
+   pecl install pdo_ibm
+   ```
+        
+2. Open the `php.ini` file in an editor of your choice. Edit the extension entry in the
+   `php.ini` file in the `<local_php_directory>/php/lib` directory to reference the PHP driver:
+
+   ```ini
+   extension=pdo_ibm.so
+   ```
+       
+3. Ensure that the PHP driver can access the `libdb2.so` CLI driver file by
+   setting the `LD_LIBRARY_PATH` variable for Linux and UNIX operating systems
+   other than the AIX® operating system. For AIX operating system, you must set `LIBPATH` variable.
+
+4. Optionally, if the PHP application that is connecting to an IBM database server is running in
+   the HTTP server environment, add the `LD_LIBRARY_PATH` variable in the `httpd.conf` file.
+
 ## Prebuilt binaries for Windows
 
 1. Add the `CLIDRIVER\bin` path to the `PATH` environment variable like so (for a batch file):
-    ```
-    set PATH=<CLIDRIVER installed path>\bin;%PATH%
-    ```
+
+   ```shell
+   set PATH=<CLIDRIVER installed path>\bin;%PATH%
+   ```
+
 2. Download the DLLs for PHP 7.x and 8.x from [the ibmdb repository](https://github.com/ibmdb/php_ibm_db2).
    Select the build for the PHP that matches the version, architecture, and thread model.
 
 3. Open the `php.ini` file in an editor of your choice. Edit the extension entry in the
    `php.ini` file in the `<local_php_directory>\php\lib` directory to reference the driver:
-    ````
-    extension=php_pdo_ibm
-    ````
+
+   ```ini
+   extension=php_pdo_ibm
+   ```
 
 ## How to run sample program
 
-### connect.php:-
+Create a `connect.php` script with the following content:
+
+```php
+<?php
+
+$dsn = 'ibm:<DSN NAME>';
+$user = '<USER>';
+$pass = '<PASSWORD>';
+
+$pdo = new \PDO($dsn, $user, $pass);
+```
+
+To run the sample:
 
 ```
-<?php
-        $db = null;
-        $dsn = "ibm:<DSN NAME>";
-        $user = "<USER>";
-        $pass = "<PASSWORD>";
-
-        $pdo = new PDO($dsn, $user, $pass);
-        if ($pdo)
-           print "Connection Successful.\n";
-
-?>
-
-
-To run the sample:- php connect.php
+php connect.php
 ```
 
 ## Contributing:
-```
-See CONTRIBUTING.md
 
-The developer sign-off should include the reference to the DCO in defect remarks(example below):
+The developer sign-off should include the reference to the DCO in defect remarks, like in this example:
+
+```
 DCO 1.1 Signed-off-by: Random J Developer <random@developer.org>
 ```


### PR DESCRIPTION
These are small syntax fixes and improvements.
Reference to `CONTRIBUTING.md` was removed, as the file does not exist.
Additionally, the higher supported version for PHP was updated to 8.2, as the CI pipeline is running against that version.