### PR TITLE
Boolean support

### DIFF
--- a/ibm_statement.c
+++ b/ibm_statement.c
@@ -353,6 +353,8 @@ static int stmt_get_parameter_info(pdo_stmt_t * stmt, struct pdo_bound_param_dat
 			* Numeric forms we can map directly to a long
 			* int value
 			*/
+			case SQL_BOOLEAN:
+			case SQL_BIT:
 			case SQL_SMALLINT:
 			case SQL_INTEGER:
 				param_res->ctype = SQL_C_LONG;
@@ -371,6 +373,8 @@ static int stmt_get_parameter_info(pdo_stmt_t * stmt, struct pdo_bound_param_dat
 static int db2_inout_parm_numeric(param_node *param_res) {
 	/* need character to number padding */
 	switch ( param_res->data_type ) {
+	case SQL_BOOLEAN:
+	case SQL_BIT:
 	case SQL_SMALLINT:
 	case SQL_INTEGER:
 	case SQL_REAL:
@@ -446,6 +450,8 @@ static void db2_inout_parm_pad_data(param_node *param_res, struct pdo_bound_para
 	* '2' becomes '000000000000000000002'
 	*/
 	switch ( param_res->data_type ) {
+	case SQL_BOOLEAN:
+	case SQL_BIT:
 	case SQL_SMALLINT:
 	case SQL_INTEGER:
 	case SQL_REAL:
@@ -591,6 +597,7 @@ int stmt_bind_parameter(pdo_stmt_t *stmt, struct pdo_bound_param_data *curr)
 			return FALSE;
 
 		/* this is a long value for PHP (or user forced) */
+		case PDO_PARAM_BOOL:
 		case PDO_PARAM_INT:
 			/*
 			* If the parameter type is a numeric type, 
@@ -634,7 +641,6 @@ int stmt_bind_parameter(pdo_stmt_t *stmt, struct pdo_bound_param_data *curr)
 			*/
 
 		/* a string value (very common) */
-		case PDO_PARAM_BOOL:
 		case PDO_PARAM_STR:
 			/*
 			* SQL_PARAM_INPUT        -- null remain untouched       (read)
@@ -1481,6 +1487,8 @@ static int ibm_stmt_describer(
 #ifdef PASE /* i5/OS size changes for "common" converts to string */
 	switch (col_res->data_type) {
 		/* BIGINT 9223372036854775807  (2^63-1) string convert */
+		case SQL_BOOLEAN:
+		case SQL_BIT:
 		case SQL_BIGINT:
 		case SQL_SMALLINT:
 		case SQL_INTEGER:
@@ -1780,6 +1788,10 @@ static int ibm_stmt_get_column_meta(
 	 * XXX: Also safe for pre-8.1?
 	 */
 	switch (col_res->data_type) {
+		/* Booleans */
+		case SQL_BOOLEAN:
+		case SQL_BIT:
+			add_assoc_long(return_value, "pdo_type", PDO_PARAM_BOOL);
 		/* LOBs */
 #ifndef PASE /* i5/OS - not LOBs */
 		case SQL_LONGVARBINARY:
@@ -1815,7 +1827,6 @@ static int ibm_stmt_get_column_meta(
 		default:
 			add_assoc_long(return_value, "pdo_type", PDO_PARAM_STR);
 			break;
-		/* XXX: PARAM_(INT|BOOL)? */
 	}
 #endif
 	return SUCCESS;

--- a/php_pdo_ibm_int.h
+++ b/php_pdo_ibm_int.h
@@ -41,6 +41,14 @@
 #define MAX_ERR_MSG_LEN (SQL_MAX_MESSAGE_LENGTH + SQL_SQLSTATE_SIZE + 1)
 #define CDTIMETYPE 112
 
+/*
+ * Added in IBM i 7.5, also in LUW 11.1 MP1/FP1
+ * see: https://www.ibm.com/docs/en/db2/11.1?topic=database-mod-pack-fix-pack-updates#c0061179__FP1
+ */
+#ifndef SQL_BOOLEAN
+#define SQL_BOOLEAN 16
+#endif
+
 #ifndef SQL_XML
 #define SQL_XML -370
 #endif

--- a/tests/fvt_boolean.phpt
+++ b/tests/fvt_boolean.phpt
@@ -14,23 +14,23 @@ pdo_ibm: Boolean data type
 
 			// Tests insert and select
 			try {
-				$c->exec("drop table booltest");
+				$this->db->exec("drop table booltest");
 			} catch (Exception $e) {}
-			$c->exec("create or replace table booltest (id integer not null, enabled boolean, primary key(id))");
+			$this->db->exec("create or replace table booltest (id integer not null, enabled boolean, primary key(id))");
 			
-			$s = $c->prepare("insert into booltest (id, enabled) values (1, ?)");
+			$s = $this->db->prepare("insert into booltest (id, enabled) values (1, ?)");
 			$x = true;
 			$s->bindParam(1, $x, PDO::PARAM_BOOL);
 			$r = $s->execute();;
 			echo " ! Inserted\n";
 			
-			$s = $c->prepare("insert into booltest (id, enabled) values (2, ?)");
+			$s = $this->db->prepare("insert into booltest (id, enabled) values (2, ?)");
 			$x = false;
 			$s->bindParam(1, $x, PDO::PARAM_BOOL);
 			$r = $s->execute();
 			echo " ! Inserted\n";
 			
-			$s = $c->prepare("select * from calvinb.booltest");
+			$s = $this->db->prepare("select * from calvinb.booltest");
 			$s->execute();
 			while ($r = $s->fetch(PDO::FETCH_ASSOC)) {
 				var_dump($r);

--- a/tests/fvt_boolean.phpt
+++ b/tests/fvt_boolean.phpt
@@ -1,0 +1,56 @@
+--TEST--
+pdo_ibm: Boolean data type
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+	require_once('fvt.inc');
+	class Test extends FVTTest
+	{
+		public function runTest()
+		{
+			// XXX: Skip on older LUW/i
+			$this->connect();
+
+			// Tests insert and select
+			try {
+				$c->exec("drop table booltest");
+			} catch (Exception $e) {}
+			$c->exec("create or replace table booltest (id integer not null, enabled boolean, primary key(id))");
+			
+			$s = $c->prepare("insert into booltest (id, enabled) values (1, ?)");
+			$x = true;
+			$s->bindParam(1, $x, PDO::PARAM_BOOL);
+			$r = $s->execute();;
+			echo " ! Inserted\n";
+			
+			$s = $c->prepare("insert into booltest (id, enabled) values (2, ?)");
+			$x = false;
+			$s->bindParam(1, $x, PDO::PARAM_BOOL);
+			$r = $s->execute();
+			echo " ! Inserted\n";
+			
+			$s = $c->prepare("select * from calvinb.booltest");
+			$s->execute();
+			while ($r = $s->fetch(PDO::FETCH_ASSOC)) {
+				var_dump($r);
+			}
+		}
+	}
+
+	$testcase = new Test();
+	$testcase->runTest();
+?>
+--EXPECT--
+array(2) {
+  ["ID"]=>
+  string(1) "1"
+  ["ENABLED"]=>
+  string(4) "TRUE"
+}
+array(2) {
+  ["ID"]=>
+  string(1) "2"
+  ["ENABLED"]=>
+  string(5) "FALSE"
+}

--- a/tests/fvt_boolean.phpt
+++ b/tests/fvt_boolean.phpt
@@ -30,7 +30,7 @@ pdo_ibm: Boolean data type
 			$r = $s->execute();
 			echo " ! Inserted\n";
 			
-			$s = $this->db->prepare("select * from calvinb.booltest");
+			$s = $this->db->prepare("select * from booltest");
 			$s->execute();
 			while ($r = $s->fetch(PDO::FETCH_ASSOC)) {
 				var_dump($r);

--- a/tests/fvt_boolean.phpt
+++ b/tests/fvt_boolean.phpt
@@ -22,13 +22,11 @@ pdo_ibm: Boolean data type
 			$x = true;
 			$s->bindParam(1, $x, PDO::PARAM_BOOL);
 			$r = $s->execute();;
-			echo " ! Inserted\n";
 			
 			$s = $this->db->prepare("insert into booltest (id, enabled) values (2, ?)");
 			$x = false;
 			$s->bindParam(1, $x, PDO::PARAM_BOOL);
 			$r = $s->execute();
-			echo " ! Inserted\n";
 			
 			$s = $this->db->prepare("select * from booltest");
 			$s->execute();

--- a/tests/fvt_boolean.phpt
+++ b/tests/fvt_boolean.phpt
@@ -31,7 +31,8 @@ pdo_ibm: Boolean data type
 			$s = $this->db->prepare("select * from booltest");
 			$s->execute();
 			while ($r = $s->fetch(PDO::FETCH_ASSOC)) {
-				var_dump($r);
+				// This can return 0/1 on LUW or TRUE/FALSE on i
+				echo $r["ID"] . ": " . $r["ENABLED"] . "\n";
 			}
 		}
 	}
@@ -39,16 +40,6 @@ pdo_ibm: Boolean data type
 	$testcase = new Test();
 	$testcase->runTest();
 ?>
---EXPECT--
-array(2) {
-  ["ID"]=>
-  string(1) "1"
-  ["ENABLED"]=>
-  string(4) "TRUE"
-}
-array(2) {
-  ["ID"]=>
-  string(1) "2"
-  ["ENABLED"]=>
-  string(5) "FALSE"
-}
+--EXPECTREGEX--
+1: (1|TRUE)
+0: (0|FALSE)

--- a/tests/fvt_boolean.phpt
+++ b/tests/fvt_boolean.phpt
@@ -42,4 +42,4 @@ pdo_ibm: Boolean data type
 ?>
 --EXPECTREGEX--
 1: (1|TRUE)
-0: (0|FALSE)
+2: (0|FALSE)

--- a/tests/fvt_boolean.phpt
+++ b/tests/fvt_boolean.phpt
@@ -16,7 +16,7 @@ pdo_ibm: Boolean data type
 			try {
 				$this->db->exec("drop table booltest");
 			} catch (Exception $e) {}
-			$this->db->exec("create or replace table booltest (id integer not null, enabled boolean, primary key(id))");
+			$this->db->exec("create table booltest (id integer not null, enabled boolean, primary key(id))");
 			
 			$s = $this->db->prepare("insert into booltest (id, enabled) values (1, ?)");
 			$x = true;


### PR DESCRIPTION
Like the PR for ibm_db2.

Binding and returning both work. It considers bools to be int-like, although it returns a "TRUE"/"FALSE" string. Changing PDO_IBM to return non-strings is out of scope. It at least works.