### PR TITLE
Don't use NTS for returned values via env attr

### DIFF
--- a/ibm_driver.c
+++ b/ibm_driver.c
@@ -1088,6 +1088,8 @@ static int dbh_connect(pdo_dbh_t *dbh, zval *driver_options)
 		rc = SQLSetEnvAttr((SQLHENV)conn_res->henv, SQL_ATTR_UTF8, (SQLPOINTER)(intptr_t)SQL_TRUE, 0);
 	}
 #endif /* PASE */
+	/* forced fixed length strings to be returned */
+	rc = SQLSetEnvAttr((SQLHENV)conn_res->henv, SQL_ATTR_OUTPUT_NTS, (SQLPOINTER)(intptr_t)SQL_FALSE, SQL_IS_INTEGER);
 
 	/* now an actual connection handle */
 	rc = SQLAllocHandle(SQL_HANDLE_DBC, conn_res->henv, &(conn_res->hdbc));


### PR DESCRIPTION
User issue on IBM i may (not necessarily) involve the driver not null terminating strings correctly. The get_col handler seems to handle this case, so let's do a CI run to see how badly this explodes on LUW. This is definitely not the right solution, but I'm curious to see how it gets handled in code paths.